### PR TITLE
CTECH-2239: Add config_keys so works with fbn_sdk_utilities.

### DIFF
--- a/sdk/finbourne_access/utilities/config_keys.py
+++ b/sdk/finbourne_access/utilities/config_keys.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import json
+
+
+class ConfigKeys:
+
+    config_key_path = "config_keys.json"
+
+    @classmethod
+    def get(cls):
+        with open(Path(__file__).parent.joinpath(cls.config_key_path)) as json_file:
+            config_keys = json.load(json_file)
+            return config_keys

--- a/sdk/tests/test_config_keys.py
+++ b/sdk/tests/test_config_keys.py
@@ -14,5 +14,5 @@ class TestConfigKeys(TestCase):
 
         # Assert
         self.assertEqual(
-            actual_config_keys, expected_config_keys_subset | actual_config_keys
+            actual_config_keys, {**actual_config_keys, **expected_config_keys_subset}
         )

--- a/sdk/tests/test_config_keys.py
+++ b/sdk/tests/test_config_keys.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+from finbourne_access.utilities.config_keys import ConfigKeys
+
+
+class TestConfigKeys(TestCase):
+    def test_identity_url_in_config_keys(self):
+        # Arrange
+        expected_config_keys_subset = {
+            "access_url": {"env": "FBN_LUSID_ACCESS_URL", "config": "accessUrl"},
+        }
+
+        # Act
+        actual_config_keys = ConfigKeys().get()
+
+        # Assert
+        self.assertEqual(
+            actual_config_keys, expected_config_keys_subset | actual_config_keys
+        )


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

Add config_keys class with get() method which allows module to be used with fbnsdkutilities.
