### PR TITLE
Feature/ctech 2239 create collateral

### DIFF
--- a/sdk/finbourne_access/utilities/api_configuration.py
+++ b/sdk/finbourne_access/utilities/api_configuration.py
@@ -1,7 +1,18 @@
 class ApiConfiguration:
-
-    def __init__(self, token_url=None, access_url=None, username=None, password=None, client_id=None, client_secret=None,
-                 app_name=None, certificate_filename=None, proxy_config=None, access_token=None):
+    def __init__(
+        self,
+        token_url=None,
+        access_url=None,
+        username=None,
+        password=None,
+        client_id=None,
+        client_secret=None,
+        app_name=None,
+        certificate_filename=None,
+        proxy_config=None,
+        access_token=None,
+        api_url=None,
+    ):
         """
         The configuration required to access LUSID, read more at https://support.finbourne.com/getting-started-with-apis-sdks
 
@@ -16,7 +27,15 @@ class ApiConfiguration:
         :param finbourne_access.utilities.ProxyConfig proxy_config: The proxy configuration to use
         """
         self.__token_url = token_url
-        self.__access_url = access_url
+        if access_url:
+            self.__access_url = access_url
+        elif api_url:
+            self.__access_url = api_url
+        else:
+            raise ValueError(
+                "ApiConfiguration must have either api_url or access_url set"
+            )
+
         self.__username = username
         self.__password = password
         self.__client_id = client_id

--- a/sdk/finbourne_access/utilities/api_configuration.py
+++ b/sdk/finbourne_access/utilities/api_configuration.py
@@ -31,11 +31,6 @@ class ApiConfiguration:
             self.__access_url = access_url
         elif api_url:
             self.__access_url = api_url
-        else:
-            raise ValueError(
-                "ApiConfiguration must have either api_url or access_url set"
-            )
-
         self.__username = username
         self.__password = password
         self.__client_id = client_id

--- a/sdk/finbourne_access/utilities/config_keys.json
+++ b/sdk/finbourne_access/utilities/config_keys.json
@@ -3,7 +3,7 @@
     "env": "FBN_TOKEN_URL",
     "config": "tokenUrl"
   },
-  "access_url": {
+  "api_url": {
     "env": "FBN_LUSID_ACCESS_URL",
     "config": "accessUrl"
   },

--- a/sdk/tests/test_config_keys.py
+++ b/sdk/tests/test_config_keys.py
@@ -6,7 +6,7 @@ class TestConfigKeys(TestCase):
     def test_identity_url_in_config_keys(self):
         # Arrange
         expected_config_keys_subset = {
-            "access_url": {"env": "FBN_LUSID_ACCESS_URL", "config": "accessUrl"},
+            "api_url": {"env": "FBN_LUSID_ACCESS_URL", "config": "accessUrl"},
         }
 
         # Act


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [] Raised the PR against the `develop` branch

# Description of the PR

Unlike other FINBOURNE SDKs, the access SDK ApiConfiguration constructor takes access_url as an arg instead of api_url. This makes it incompatible with fbnsdkutilities.
This backwards compatible change adds api_url to the config_keys.json and to the api_configuration constructor.